### PR TITLE
Show valid count stats on home page

### DIFF
--- a/ckanext/biskit/templates/home/layout1.html
+++ b/ckanext/biskit/templates/home/layout1.html
@@ -48,35 +48,7 @@
           The answers to your basic questions and even more complex questions can be mined from our datasets. Here is the number of datasets, organisations & groups available for mining.
         </h3>
       </div>
-      <div class="row row2">
-        <div class="col-md-4">
-          <div class="card-2">
-            <div class="card-2-con"><img class="card-2-img" src="/img/dataset1.png"></div>
-            <div>
-              <h4>500</h4>
-              <p>Number of Datasets</p>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-4">
-          <div class="card-2">
-            <div class="card-2-con"><img class="card-2-img" src="/img/org1.png"></div>
-            <div>
-              <h4>255</h4>
-              <p>Number of Organizations</p>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-4">
-          <div class="card-2">
-            <div class="card-2-con"><img class="card-2-img" src="/img/group1.png"></div>
-            <div>
-              <h4>50</h4>
-              <p>Number of Groups</p>
-            </div>
-          </div>
-        </div>
-      </div>
+      {% snippet 'home/snippets/stats.html' %}
 
       <div class="show-all">
         <hr class="side-rule"> <button>Show all datasets</button> <hr class="side-rule">

--- a/ckanext/biskit/templates/home/snippets/stats.html
+++ b/ckanext/biskit/templates/home/snippets/stats.html
@@ -1,0 +1,32 @@
+{% set stats = h.get_site_statistics() %}
+{% set top_nodes = h.group_tree_highlight(organizations, h.group_tree(type_='organization')) %}
+
+<div class="row row2">
+  <div class="col-md-4">
+    <div class="card-2">
+      <div class="card-2-con"><img class="card-2-img" src="/img/dataset1.png"></div>
+      <div>
+        <h4>{{ h.SI_number_span(stats.dataset_count) }}</h4>
+        <p>Number of Datasets</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card-2">
+      <div class="card-2-con"><img class="card-2-img" src="/img/org1.png"></div>
+      <div>
+        <h4>{{ top_nodes | length }}</h4>
+        <p>Number of Organizations</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card-2">
+      <div class="card-2-con"><img class="card-2-img" src="/img/group1.png"></div>
+      <div>
+        <h4>{{ h.SI_number_span(stats.group_count) }}</h4>
+        <p>Number of Groups</p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Description

Reflect actual count for organizations, groups and public datasets on the portal.

## Todos

- [x] Tested and working locally
- [ ] Unit tests added (if appropriate)
- [ ] Code changes documented
- [x] Requested review from >=2 devs on the team

## How to test
- Add organizations, groups and public datasets
- Visit home page to confirm stats reflects total number of organizations, groups and public datasets on the portal

## Screenshots and/or Gifs
**Static Stats**
![Screen Shot 2020-11-10 at 5 04 40 PM](https://user-images.githubusercontent.com/2089370/98706089-b71e4d80-237e-11eb-856c-3a8d0709d180.png)

**Dynamic Stats**
![Screen Shot 2020-11-10 at 5 56 56 PM](https://user-images.githubusercontent.com/2089370/98706124-c0a7b580-237e-11eb-8cc0-cd103ab9fb43.png)

## Associated JIRA Tasks

- [BSA-24: Link and make portal stats on homepage active](https://jira.ehealthafrica.org/projects/BSA/issues/BSA-24)

## Known Issues

- N/A
