### PR TITLE
fix: restore dataset form

### DIFF
--- a/ckanext/biskit/templates/home/about.html
+++ b/ckanext/biskit/templates/home/about.html
@@ -6,7 +6,7 @@
 
 
           <div class="container-fluid top-desc">
-            <h2> Blood Information System for Krisis Intervention and Management.</h2>
+            <h2> Blood Information System for Crisis Intervention and Management.</h2>
           </div>
 
       {% block primary %}

--- a/ckanext/biskit/templates/home/snippets/search.html
+++ b/ckanext/biskit/templates/home/snippets/search.html
@@ -13,7 +13,6 @@
   </form>
   <div class="tags">
     <span>{{ _('Popular tags :') }}</span>
-    <a class="tag" href="#">Hospital</a><a class="tag" href="#">Supplier</a>
     {% for tag in tags %}
       <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name %}">{{ h.truncate(tag.display_name, 22) }}</a>
     {% endfor %}

--- a/ckanext/biskit/templates/package/base_form_page.html
+++ b/ckanext/biskit/templates/package/base_form_page.html
@@ -1,24 +1,16 @@
-{% extends "package/edit_base.html" %}
+{% ckan_extends %}
 
-
-{% block secondary_content %}
-  {% block info_module %}
-    <section class="module module-narrow module-shallow">
-      <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('What are datasets?') }}</h2>
-      <div class="module-content">
-        <p>
-          {% trans %}
-          A Dataset is a collection of data resources (such as files),
-          together with a description and other information, at a fixed URL.
-          Datasets are what users see when searching for data.
-          {% endtrans %}
-        </p>
-      </div>
-    </section>
-  {% endblock %}
-
-  {% block resources_module %}
-    {# TODO: Pass in a list of previously created resources and the current package dict #}
-    {% snippet "package/snippets/resources.html", pkg={}, action='new_resource' %}
-  {% endblock %}
+{% block info_module %}
+  <section class="module module-narrow module-shallow">
+    <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('What are datasets?') }}</h2>
+    <div class="module-content">
+      <p>
+        {% trans %}
+        A Dataset is a collection of data resources (such as files),
+        together with a description and other information, at a fixed URL.
+        Datasets are what users see when searching for data.
+        {% endtrans %}
+      </p>
+    </div>
+  </section>
 {% endblock %}


### PR DESCRIPTION
# Description

Restore missing dataset creation/update form.

## Todos

- [x] Tested and working locally
- [ ] Unit tests added (if appropriate)
- [ ] Code changes documented
- [x] Requested review from >=2 devs on the team

## How to test
- add an organization if one doesn't already exist
- attempt adding a new dataset; the form should be displayed

## Screenshots and/or Gifs
![Screen Shot 2021-01-13 at 6 51 46 PM](https://user-images.githubusercontent.com/2089370/104489932-80f48880-55d0-11eb-9f37-c04a775696c0.png)

## Associated JIRA Tasks
- N/A

## Known Issues
- N/A
